### PR TITLE
[cli] add `lmlsb extractcsv` and `lmlsb insertcsv` commands

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -380,6 +380,59 @@ Users generating translation patches may be more interested in ``batchinsert``. 
                                     file(s).
       --help                        Show this message and exit.
 
+extractcsv
+^^^^^^^^^^
+
+Extract LiveNovel scenario text lines from an LSB file to a CSV file.
+
+.. note:: Only text lines are extracted, so some formatting information may be lost.
+   For translating games which make heavy use of formatting tags, you may need to consider using
+   ``lmlsb extract`` and ``lmlsb insert`` to translate fully decompiled scripts instead of using
+   the CSV commands.
+
+::
+
+    lmlsb extractcsv --help
+    Usage: lmlsb extractcsv [OPTIONS] LSB_FILE CSV_FILE
+
+      Extract text lines from the given LSB file to a CSV file.
+
+      You can open this csv file for translation in most table calc programs
+      (Excel, open/libre office calc, ...). Just remember to choose comma as
+      delimiter and " as quotechar.
+
+      You can use the --append option to add the text data from this lsb file to
+      a existing csv. With the --overwrite option an existing csv will be
+      overwritten without warning.
+
+      NOTE: Formatting tags will be lost when using this command in conjunction
+      with insertcsv. For translating games which use formatting tags, you may
+      need to work directly with LNS scripts using the extract and
+      insert/batchinsert commands.
+
+    Options:
+      --overwrite  Overwrite existing csv file.
+      --append     Append text data to existing csv file.
+      --help       Show this message and exit.
+
+insertcsv
+^^^^^^^^^
+
+Insert (translated) LiveNovel scenario text lines from a CSV file into an LSB file. ::
+
+    lmlsb insertcsv --help
+    Usage: lmlsb insertcsv [OPTIONS] LSB_FILE CSV_FILE
+
+      Apply translated text lines from the given CSV file to given LSB file.
+
+      CSV_FILE should be a file previously created by the extractcsv command,
+      with added translations. The original LSB file will be backed up to
+      <lsb_file>.bak unless the --no-backup option is specified.
+
+    Options:
+      --no-backup  Do not generate backup of original lsb file.
+      --help       Show this message and exit.
+
 probe
 ^^^^^
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -35,6 +35,8 @@ To try and patch something:
     $ cp orig_scripts/*.lns translated_scripts
     <run your favorite text editor on whatever script you want to translate>
 
+.. note:: If you do not need access LiveNovel script tags for your game, you can also work with script text lines using the ``lmlsb extractcsv`` and ``lmlsb insertcsv`` commands (instead of ``lmlsb extract`` and ``lmlsb insert`` in steps 3 and 4).
+
 5. Patch the new script back into the lsb. ::
 
     $ lmlsb insert 00000001.lsb scripts_dir/<translated_script>.lns 1234

--- a/livemaker/cli/lmlsb.py
+++ b/livemaker/cli/lmlsb.py
@@ -23,6 +23,7 @@ import hashlib
 import shutil
 import sys
 import csv
+from collections import defaultdict
 from pathlib import Path
 
 import click
@@ -204,8 +205,9 @@ def dump(mode, encoding, output_file, input_file):
                     name = "{}-line{}.lns".format(lsb_path.stem, line)
                 print(name, file=outf)
                 print("------", file=outf)
-                for line in scenario.get_lines():
-                    print(line, file=outf)
+                for block in scenario.get_text_blocks():
+                    for line in block.lines:
+                        print(line, file=outf)
         else:
             for c in lsb.commands:
                 if c.Mute:
@@ -1163,13 +1165,31 @@ def scan_menus(lsb, csv_data, file_name, extract=False, patch=False):
 @lmlsb.command()
 @click.argument("lsb_file", required=True, type=click.Path(exists=True, dir_okay="False"))
 @click.argument("csv_file", required=True, type=click.Path(exists=False, dir_okay="False"))
+@click.option(
+    "-m", "--mode", type=click.Choice(["blocks", "lines"]), default="blocks", help="Output mode (defaults to blocks)"
+)
+@click.option(
+    "-e",
+    "--encoding",
+    type=click.Choice(["cp932", "utf-8", "utf-8-sig"]),
+    default="utf-8",
+    help="Output text encoding (defaults to utf-8).",
+)
 @click.option("--overwrite", is_flag=True, default=False, help="Overwrite existing csv file.")
 @click.option("--append", is_flag=True, default=False, help="Append text data to existing csv file.")
-def extractcsv(lsb_file, csv_file, overwrite, append):
-    """Extract text lines from the given LSB file to a CSV file.
+def extractcsv(lsb_file, csv_file, mode, encoding, overwrite, append):
+    """Extract text from the given LSB file to a CSV file.
 
-    You can open this csv file for translation in most table calc programs (Excel, open/libre office calc, ...).
+    If --mode is set to "blocks", CSV will contain one row per text block, and newlines in text block will
+    be treated as <BR> line breaks.
+    If --mode is set to "lines", CSV will contain one row per text line, and line breaks cannot be added or removed.
+    (Defaults to "blocks" mode)
+
+    You can open this CSV file for translation in most spreadsheet programs (Excel, Open/Libre Office Calc, etc).
     Just remember to choose comma as delimiter and " as quotechar.
+
+    NOTE: If you are using Excel and UTF-8 text, you must also specify --encoding=utf-8-sig, since Excel requires
+    UTF-8 with BOM to handle UTF-8 properly.
 
     You can use the --append option to add the text data from this lsb file to a existing csv.
     With the --overwrite option an existing csv will be overwritten without warning.
@@ -1194,8 +1214,12 @@ def extractcsv(lsb_file, csv_file, overwrite, append):
             name = "{}-{}".format(lsb_file.stem, name)
         if not name:
             name = "{}-line{}".format(lsb_file.stem, lsb_line)
-        for line in scenario.get_lines():
-            csv_data.append([str(lsb_file), name, line.text, None])
+        for i, block in enumerate(scenario.get_text_blocks()):
+            if mode == "blocks":
+                csv_data.append([str(lsb_file), name, i, block.text, None])
+            else:
+                for line in block.lines:
+                    csv_data.append([str(lsb_file), name, i, line, None])
 
     if len(csv_data) == 0:
         sys.exit("No text data found.")
@@ -1207,56 +1231,88 @@ def extractcsv(lsb_file, csv_file, overwrite, append):
         print("File {} does not exist, but --append specified. A new file will be created.".format(csv_file))
         append = False
 
-    with open(csv_file, ("a" if append else "w"), newline="\n") as csvfile:
+    with open(csv_file, ("a" if append else "w"), newline="\n", encoding=encoding) as csvfile:
         csv_writer = csv.writer(csvfile, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL)
         if not append:
-            csv_writer.writerow(["Filename", "Scenario name", "Original entry", "Translated entry"])
+            csv_writer.writerow(["Filename", "Scenario name", "Block index", "Original entry", "Translated entry"])
         for row in csv_data:
             csv_writer.writerow(row)
 
-    print("{} Text lines extracted.".format(len(csv_data)))
+    print("{} Text {} extracted.".format(len(csv_data), mode))
 
 
-def _patch_csv_lines(lsb, lsb_file, csv_data):
+def _patch_csv_text(lsb, lsb_file, csv_data, mode="blocks"):
     """Patch text lines in the given lsb file using csv_data."""
-    patched = False
+    lsb_scenarios = {}
     for lsb_line, name, scenario in lsb.text_scenarios():
         if name:
             name = "{}-{}".format(lsb_file.stem, name)
         if not name:
             name = "{}-line{}".format(lsb_file.stem, lsb_line)
+        lsb_scenarios[name] = scenario
 
-        new_lines = []
-        for csv_lsb_file, csv_name, orig_text, translated_text in csv_data:
-            if csv_lsb_file == str(lsb_file) and csv_name == name:
-                if not translated_text:
-                    print('Untranslated text "{}" for {}! Not patched!'.format(orig_text, csv_name))
-                    new_lines.append(orig_text)
-                else:
-                    print('Patched "{}" to "{}" for {}'.format(orig_text, translated_text, csv_name))
-                    new_lines.append(translated_text)
-                    patched = True
+    translated = {}
+    # parse csv for blocks we care about
+    csv_blocks = defaultdict(list)
+    for csv_lsb_file, csv_name, block_index, orig_text, translated_text in csv_data:
+        if csv_lsb_file == str(lsb_file) and csv_name in lsb_scenarios:
+            if translated_text:
+                print('Will translate "{}" to "{}" for {}'.format(orig_text, translated_text, csv_name))
+                text = translated_text
+                translated[csv_name] = True
+            else:
+                print('Untranslated text "{}" for {}, using original text!'.format(orig_text, csv_name))
+                text = orig_text
+            csv_blocks[(csv_name, int(block_index))].append(text)
 
-        if patched:
-            lines = scenario.get_lines()
-            if len(lines) != len(new_lines):
-                raise LiveMakerException(
-                    "CSV line count does not match original scenario line count for {}".format(name)
-                )
-            for i, line in enumerate(lines):
-                line.text = new_lines[i]
-            scenario.replace_lines(lines)
-    return patched
+    # update translated scenarios
+    for name, scenario in lsb_scenarios.items():
+        if name not in translated:
+            continue
+
+        blocks = scenario.get_text_blocks()
+        for i, block in enumerate(blocks):
+            new_blocks = csv_blocks[(name, i)]
+            if not new_blocks:
+                # ignore missing scenario blocks
+                continue
+            if mode == "blocks":
+                if len(new_blocks) > 1:
+                    raise LiveMakerException(
+                        "Invalid blocks mode CSV: multiple entries for scenario '{}' block {}".format(name, i)
+                    )
+                block.text = new_blocks[0]
+            else:
+                if len(block.lines) != len(new_blocks):
+                    raise LiveMakerException(
+                        "Invalid lines mode CSV: line count does not match original line count for "
+                        "scenario '{}' block {}".format(name, i)
+                    )
+                block.text = "\n".join(new_blocks)
+        scenario.replace_text_blocks(blocks)
+    return bool(translated)
 
 
 @lmlsb.command()
 @click.argument("lsb_file", required=True, type=click.Path(exists=True, dir_okay="False"))
 @click.argument("csv_file", required=True, type=click.Path(exists=False, dir_okay="False"))
+@click.option(
+    "-m", "--mode", type=click.Choice(["blocks", "lines"]), default="blocks", help="Output mode (defaults to blocks)"
+)
+@click.option(
+    "-e",
+    "--encoding",
+    type=click.Choice(["cp932", "utf-8", "utf-8-sig"]),
+    default="utf-8",
+    help="Output text encoding (defaults to utf-8).",
+)
 @click.option("--no-backup", is_flag=True, default=False, help="Do not generate backup of original lsb file.")
-def insertcsv(lsb_file, csv_file, no_backup):
+def insertcsv(lsb_file, csv_file, mode, encoding, no_backup):
     """Apply translated text lines from the given CSV file to given LSB file.
 
     CSV_FILE should be a file previously created by the extractcsv command, with added translations.
+    --encoding and --mode options must match the values were used for extractcsv.
+
     The original LSB file will be backed up to <lsb_file>.bak unless the --no-backup option is specified.
     """
     lsb_file = Path(lsb_file)
@@ -1271,12 +1327,12 @@ def insertcsv(lsb_file, csv_file, no_backup):
 
     csv_data = []
 
-    with open(csv_file, newline="\n") as csvfile:
+    with open(csv_file, newline="\n", encoding=encoding) as csvfile:
         csv_reader = csv.reader(csvfile, delimiter=",", quotechar='"')
         for row in csv_reader:
             csv_data.append(row)
 
-    patched = _patch_csv_lines(lsb, lsb_file, csv_data)
+    patched = _patch_csv_text(lsb, lsb_file, csv_data, mode=mode)
 
     if not patched:
         sys.exit("No text lines patched, so not need to change LSB file.")

--- a/livemaker/cli/lmlsb.py
+++ b/livemaker/cli/lmlsb.py
@@ -204,9 +204,8 @@ def dump(mode, encoding, output_file, input_file):
                     name = "{}-line{}.lns".format(lsb_path.stem, line)
                 print(name, file=outf)
                 print("------", file=outf)
-                dec = LNSDecompiler(text_only=True)
-                print(dec.decompile(scenario), file=outf)
-                print(file=outf)
+                for line in scenario.get_lines():
+                    print(line, file=outf)
         else:
             for c in lsb.commands:
                 if c.Mute:

--- a/livemaker/cli/lmlsb.py
+++ b/livemaker/cli/lmlsb.py
@@ -1159,3 +1159,154 @@ def scan_menus(lsb, csv_data, file_name, extract=False, patch=False):
         c = None
 
     return patched
+
+
+@lmlsb.command()
+@click.argument("lsb_file", required=True, type=click.Path(exists=True, dir_okay="False"))
+@click.argument("csv_file", required=True, type=click.Path(exists=False, dir_okay="False"))
+@click.option("--overwrite", is_flag=True, default=False, help="Overwrite existing csv file.")
+@click.option("--append", is_flag=True, default=False, help="Append text data to existing csv file.")
+def extracttext(lsb_file, csv_file, overwrite, append):
+    """Extract texts from the given lsb file to a csv file.
+    You can open this csv file for translation in most table calc programs (Execl, open/libe office calc, ...).
+    Just remember to chose comma as delimiter and " as quotechar.
+    You can use the --append option to add the text data from this lsb file to a existing csv.
+    With the --overwrite option an existing csv will be overwritten without warning.
+    """
+    print("Extracting {} ...".format(lsb_file))
+
+    with open(lsb_file, "rb") as f:
+        data = f.read()
+    try:
+        lsb = LMScript.from_lsb(data)
+    except BadLsbError as e:
+        sys.exit("Failed to parse file: {}".format(e))
+
+    csv_data = []
+    scan_texts(lsb, csv_data, lsb_file, extract=True)
+
+    if len(csv_data) == 0:
+        sys.exit("No text data found.")
+
+    if Path(csv_file).exists():
+        if not overwrite and not append:
+            sys.exit("File {} already exists. Please use --overwrite or --append option.".format(csv_file))
+    elif append:
+        print("File {} does not exist, but --append specified. A new file will be created.".format(csv_file))
+        append = False
+
+    with open(csv_file, ("a" if append else "w"), newline="\n") as csvfile:
+        csv_writer = csv.writer(csvfile, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL)
+        if not append:
+            csv_writer.writerow(["Filename", "Command line", "Command subindex", "Original entry", "Translated entry"])
+        for row in csv_data:
+            csv_writer.writerow(row)
+
+    print("{} Text lines extracted.".format(len(csv_data)))
+
+
+@lmlsb.command()
+@click.argument("lsb_file", required=True, type=click.Path(exists=True, dir_okay="False"))
+@click.argument("csv_file", required=True, type=click.Path(exists=False, dir_okay="False"))
+@click.option("--no-backup", is_flag=True, default=False, help="Do not generate backup of original lsb file.")
+def inserttext(lsb_file, csv_file, no_backup):
+    """Apply translated texts from the given csv file on a given lsb file.
+    The csv file have to be created by the extracttext function and translations have to be added.
+    The original LSB file will be backed up to <lsb_file>.bak unless the
+    --no-backup option is specified.
+    """
+    print("Patching {} ...".format(lsb_file))
+
+    with open(lsb_file, "rb") as f:
+        data = f.read()
+    try:
+        lsb = LMScript.from_lsb(data)
+    except BadLsbError as e:
+        sys.exit("Failed to parse file: {}".format(e))
+
+    csv_data = []
+
+    with open(csv_file, newline="\n") as csvfile:
+        csv_reader = csv.reader(csvfile, delimiter=",", quotechar='"')
+        for row in csv_reader:
+            csv_data.append(row)
+
+    patched = scan_texts(lsb, csv_data, lsb_file, patch=True)
+
+    if not patched:
+        sys.exit("No text lines patched, so not need to change LSB file.")
+
+    if not no_backup:
+        print("Backing up original LSB.")
+        shutil.copyfile(str(lsb_file), "{}.bak".format(str(lsb_file)))
+    try:
+        new_lsb_data = lsb.to_lsb()
+        with open(lsb_file, "wb") as f:
+            f.write(new_lsb_data)
+        print("Wrote new LSB.")
+    except LiveMakerException as e:
+        sys.exit('Could not generate new LSB file: {}'.format(e))
+
+
+def scan_texts(lsb, csv_data, file_name, extract=False, patch=False):
+    """Scan given lsb object for TextIns, extract or patch TWdChar blocks
+    lsb: the lsb object loaded by LMScript.from_lsb
+    csv_data: translation data from the csv file
+    file_name: name of the lsb file
+    extract: true if you want to extract text
+    patch: true if you want to patch translated text
+    """
+    patched = False
+    for cmd_nr, cmd in enumerate(lsb.commands):
+        if cmd.type == CommandType.TextIns:
+            scenario = cmd.get('Text')
+            text_line = None
+            block_nr = 0
+            new_body = []
+            last_ch = None
+            cmd_patched = False
+            for w in scenario.body:
+                if w.type == TWdType.TWdChar:
+                    if text_line:
+                        text_line = text_line + str(w.ch)
+                    else:
+                        text_line = str(w.ch)
+                        block_nr += 1
+                    last_ch = w
+                else:
+                    if text_line:
+                        if extract:
+                            csv_data.append([file_name, cmd_nr, block_nr, text_line, None])
+
+                        if patch:
+                            for csv_line in csv_data:
+                                if csv_line[0] == file_name and csv_line[1] == str(cmd_nr) and csv_line[2] == str(block_nr):
+                                    if csv_line[4] == "":
+                                        print("Untranslated text \"{}\" at Command {}.{}! Not patched!".format(text_line, cmd_nr, block_nr))
+                                        new_line = text_line
+                                    else:
+                                        print("Patched \"{}\" to \"{}\" at Command {}.{}".format(text_line, csv_line[4], cmd_nr, block_nr))
+                                        new_line = csv_line[4]
+                                        cmd_patched = True
+                                    for ch in new_line:
+                                        new_ch = TWdChar(
+                                            ch = ch,
+                                            decorator = last_ch.decorator,
+                                            text_speed = last_ch.text_speed,
+                                            link_name = last_ch.link_name,
+                                            link = last_ch.link,
+                                            condition = last_ch.condition,
+                                        )
+                                        new_body.append(new_ch)
+
+                        text_line = ""
+
+                    if patch:
+                        new_body.append(w)
+
+                    block_nr += 1
+
+            if patch and cmd_patched:
+                patched = True
+                scenario.body = new_body
+    return patched

--- a/livemaker/cli/lmlsb.py
+++ b/livemaker/cli/lmlsb.py
@@ -1308,5 +1308,5 @@ def scan_texts(lsb, csv_data, file_name, extract=False, patch=False):
 
             if patch and cmd_patched:
                 patched = True
-                scenario.body = new_body
+                scenario.replace_body(new_body)
     return patched

--- a/livemaker/cli/lmlsb.py
+++ b/livemaker/cli/lmlsb.py
@@ -32,7 +32,7 @@ from lxml import etree
 
 from livemaker.lsb.command import BaseComponentCommand, Calc, CommandType, Jump
 from livemaker.lsb.core import OpeData, OpeDataType, OpeFuncType, Param, ParamType
-from livemaker.lsb.novel import LNSDecompiler, LNSCompiler, TWdChar, TWdOpeReturn
+from livemaker.lsb.novel import LNSDecompiler, LNSCompiler, TWdChar, TWdOpeReturn, TWdType
 from livemaker.exceptions import LiveMakerException, BadLsbError
 from livemaker.lsb import LMScript
 

--- a/livemaker/lsb/novel.py
+++ b/livemaker/lsb/novel.py
@@ -23,6 +23,9 @@ import logging
 import os
 import re
 import _markupbase
+from bisect import bisect
+from copy import copy
+from hashlib import blake2b
 
 import construct
 
@@ -850,6 +853,33 @@ class TpWord(BaseSerializable):
             for i, link in enumerate(self.links):
                 link.count = link_counts[i]
 
+    def get_lines(self):
+        """Return :class:`LNSLines` for this TpWord block."""
+        return LNSLines.from_tpword(self)
+
+    def replace_lines(self, lines, strict=True):
+        """Replace text lines for this block with the contents of ``lines``.
+
+        Args:
+            lines (:class:`LNSLines`): Replacement lines. ``lines`` should be an object
+                previously returned by `get_lines()` (but with modified text).
+            strict (bool): If True, `BadLnsError` will be raised if ``lines`` contains lines
+                with blake2 digests which do not match the current TpWord block.
+        """
+        if strict and lines != self.get_lines():
+            raise BadLnsError("Replacement lines do not match this TpWord block.")
+        # iterate in reverse so we can use slice assignment
+        for line in reversed(lines):
+            start = line.start
+            # use style/cond/link/etc values for initial char
+            start_ch = self.body[start]
+            new_line = []
+            for ch in line.text:
+                new_ch = copy(start_ch)
+                new_ch.ch = ch
+                new_line.append(new_ch)
+            self.body[line.start : line.end] = new_line
+
 
 class LNSDecompiler(object):
     """Attempt to decompile a TpWord text block into something that resembles
@@ -1499,3 +1529,133 @@ class LNSCompiler(_markupbase.ParserBase):
         for i, j in [('\\"', '"'), ("\\<", "<"), ("\\>", ">"), ("\\{", "{"), ("\\}", "}"), ("\\\\", "\\")]:
             s = s.replace(i, j)
         return s
+
+
+class LNSTextLine:
+    """Contiguous text line in a TpWord block.
+
+    Args:
+        text (str): line text string.
+        start (int): TpWord body index of the first TWdChar in this line
+        end (int): TpWord body index of the first TWdGlyph following this line.
+            If `end` is None, it will be set to ``start + len(text)``.
+
+    When working with `LNSTextLine` objects, the ``text`` attribute can be manipulated freely.
+    The read-only ``digest``, ``start`` and ``end`` attributes will always remain tied to the original
+    TpWord body, to ensure that modified (i.e. translated) lines are inserted in the correct position,
+    even if the translated line differs in length from the original.
+
+    Note:
+        Line equality (``__eq__``) is tested based on matching ``start``, ``end``, ``digest`` attributes.
+        To test string equality between lines, compare the ``text`` attributes.
+    """
+
+    def __init__(self, text, start, end=None):
+        self.text = text
+        self._start = start
+        if self._start < 0:
+            raise ValueError("LNSTextLine start must be >= 0")
+        if end is None:
+            self._end = start + len(text)
+        else:
+            self._end = end
+        if self._end <= start:
+            raise ValueError("LNSTextLine end must be > start")
+        self._digest = self.blake2(text)
+
+    @property
+    def start(self):
+        return self._start
+
+    @property
+    def end(self):
+        return self._end
+
+    @property
+    def digest(self):
+        return self._digest
+
+    def __hash__(self):
+        return hash((self.start, self.end, self.digest))
+
+    def __eq__(self, other):
+        return hash(self) == hash(other)
+
+    def __lt__(self, other):
+        return self.start < other.start and self.end < other.end
+
+    def overlaps(self, other):
+        return (self.start >= other.start and self.start < other.end) or (
+            self.end > other.start and self.end <= other.end
+        )
+
+    def __str__(self):
+        return str(self.text)
+
+    @staticmethod
+    def blake2(text):
+        hash_ = blake2b(digest_size=8)
+        hash_.update(text.encode("utf-8"))
+        return hash_.hexdigest()
+
+
+class LNSLines:
+    """Convenience container for accessing text lines in a TpWord block."""
+
+    def __init__(self, strict=True):
+        self._lines = []
+        self.strict = strict
+
+    def __len__(self):
+        return len(self._lines)
+
+    def __iter__(self):
+        return iter(self._lines)
+
+    def __reversed__(self):
+        return reversed(self._lines)
+
+    def __getitem__(self, key):
+        if not self._lines:
+            raise IndexError
+        if key < 0:
+            key %= len(self._lines)
+        return self._lines[key]
+
+    def __eq__(self, other):
+        if len(self) != len(other):
+            return False
+        for i, line in enumerate(self._lines):
+            if line != other[i]:
+                return False
+        return True
+
+    def add(self, line):
+        """Add the specified line to this container."""
+        index = bisect(self._lines, line)
+        if self.strict:
+            for i in (index, index + 1):
+                if i < len(self) and self._lines[i].overlaps(line):
+                    raise BadLnsError("Invalid overlapping LNS lines")
+        self._lines.insert(index, line)
+
+    @classmethod
+    def from_tpword(cls, tpword):
+        """Return lines object for the specified TpWord block.
+
+        Args:
+            tpword (:class:`TpWord`): TpWord block to parse
+        """
+        lines = LNSLines()
+        cur_line = []
+        start = 0
+        for i, w in enumerate(tpword.body):
+            if w.type == TWdType.TWdChar:
+                if not cur_line:
+                    start = i
+                cur_line.append(str(w.ch))
+            elif cur_line:
+                text = "".join(cur_line)
+                cur_line.clear()
+                lines.add(LNSTextLine(text, start))
+        return lines

--- a/livemaker/lsb/novel.py
+++ b/livemaker/lsb/novel.py
@@ -24,7 +24,7 @@ import os
 import re
 import _markupbase
 from bisect import bisect
-from hashlib import blake2b
+from hashlib import sha256
 
 import construct
 
@@ -877,7 +877,7 @@ class TpWord(BaseSerializable):
             blocks (:class:`LNSText`): Replacement blocks. ``blocks`` should be an object
                 previously returned by `get_text_blocks()` (but with modified text).
             strict (bool): If True, `BadLnsError` will be raised if ``blocks`` contains blocks
-                with blake2 digests which do not match the current TpWord.
+                with SHA256 digests which do not match the current TpWord.
         """
         new_body = self.body[:]
         if strict and blocks != self.get_text_blocks():
@@ -1585,7 +1585,7 @@ class LNSTextBlock:
             self._end = end
         if self._end <= start:
             raise ValueError("LNSTextLine end must be > start")
-        self._digest = self.blake2(self.text)
+        self._digest = self.text_digest(self.text)
 
     @property
     def start(self):
@@ -1629,10 +1629,10 @@ class LNSTextBlock:
         return str(self.text)
 
     @staticmethod
-    def blake2(text):
-        hash_ = blake2b(digest_size=8)
+    def text_digest(text):
+        hash_ = sha256()
         hash_.update(text.encode("utf-8"))
-        return hash_.hexdigest()
+        return hash_.hexdigest()[16]
 
 
 class LNSText:


### PR DESCRIPTION
(probably) replaces #33 

* rename commands from old PR to `extractcsv` and `insertcsv`
* adjust CSV columns to be more consistent with other pylivemaker commands
    * use the same `xxxx-<name>` or `xxxx-linenum` convention used in `lmlsb extract` for labeling specific scenarios
* move non-CSV related logic into new `TpWord.get_lines()` and `TpWord.replace_lines()` API methods