### PR TITLE
[cli] add lmlpb tool

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -131,6 +131,67 @@ scenario flowchart. The output graph will include menu choice/route branch condi
       --version  Show the version and exit.
       --help     Show this message and exit.
 
+lmlpb
+-----
+
+Use ``lmlpb`` to work with LPB (LiveMaker project settings) files. ::
+
+    $ lmlpb --help
+    Usage: lmlpb [OPTIONS] COMMAND [ARGS]...
+
+      Command-line tool for manipulating LPB project settings.
+
+    Options:
+      --version  Show the version and exit.
+      --help     Show this message and exit.
+
+    Commands:
+      edit   Edit the specified LPB file.
+      probe  Output information about the specified LPB file in human-readable...
+
+probe
+^^^^^
+
+Output general information about an LPB file. ::
+
+    Usage: lmlpb probe [OPTIONS] file
+
+      Output information about the specified LPB file in human-readable form.
+
+    Options:
+      --help  Show this message and exit.
+
+edit
+^^^^
+
+Edit project settings within an LPB file.
+
+``lmlpb edit`` provides an interactive prompt that can be used to modify project settings in an LPB file.
+
+For users generating translation patches, this command may be useful for modifying the application name, certain message prompts, and the default text display and audio settings.
+
+.. warning:: This command should only be used by advanced users.
+    Do not edit an LPB setting unless you are absolutely sure of what that setting does.
+    Improper use of this command may cause undefined behavior (or a complete crash) in the LiveMaker engine during runtime.
+
+::
+
+    $ lmlpb edit --help
+    Usage: lmlpb edit [OPTIONS] LPB_FILE
+
+      Edit the specified LPB file.
+
+      Only specific settings can be edited.
+
+      The original LPB file will be backed up to <lpb_file>.bak
+
+      Note: Setting empty fields to improper data types may cause undefined
+      behavior in the LiveMaker engine. When editing a field, the data type of
+      the new value is assumed to be the same as the original data type.
+
+    Options:
+      --help  Show this message and exit.
+
 lmlsb
 -----
 

--- a/livemaker/cli/__init__.py
+++ b/livemaker/cli/__init__.py
@@ -22,7 +22,8 @@
 from .cli import galconvert
 from .lmar import lmar
 from .lmgraph import lmgraph
+from .lmlpb import lmlpb
 from .lmlsb import lmlsb
 from .lmpatch import lmpatch
 
-__all__ = ["galconvert", "lmar", "lmgraph", "lmlsb", "lmpatch"]
+__all__ = ["galconvert", "lmar", "lmgraph", "lmlpb", "lmlsb", "lmpatch"]

--- a/livemaker/cli/lmlpb.py
+++ b/livemaker/cli/lmlpb.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8
+#
+# Copyright (C) 2020 Peter Rowlands <peter@pmrowla.com>
+# Copyright (C) 2014 tinfoil <https://bitbucket.org/tinfoil/>
+#
+# This file is a part of pylivemaker.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+# -*- coding: utf-8 -*-
+"""LiveMaker LPB project settings CLI tool."""
+
+import shutil
+import sys
+
+import click
+
+from livemaker.exceptions import LiveMakerException, BadLpbError
+from livemaker.lpb import LMProject
+from livemaker.lsb.core import Param, ParamType
+
+from .cli import _version, __version__
+from .lmlsb import _edit_parser_op
+
+
+@click.group()
+@click.version_option(version=__version__, message=_version)
+def lmlpb():
+    """Command-line tool for manipulating LPB project settings."""
+    pass
+
+
+@lmlpb.command()
+@click.argument("input_file", metavar="file", required=True, type=click.Path(exists=True, dir_okay=False))
+def probe(input_file):
+    """Output information about the specified LPB file in human-readable form.
+
+    """
+    print(input_file)
+    with open(input_file, "rb") as f:
+        try:
+            lpb = LMProject.from_file(f)
+        except BadLpbError as e:
+            sys.exit("Could not read file: {}".format(e))
+    print("LiveMaker project settings file:")
+    print("  Version: {} (LiveMaker{})".format(lpb.version, lpb.lm_version))
+    print("  Project Name: {}".format(lpb.project_name))
+    print("  Project dir: {}".format(lpb.project_dir))
+    print("  Init LSB: {}".format(lpb.init_lsb))
+    print("  Exit LSB: {}".format(lpb.exit_lsb))
+    print("  Settings:")
+    for setting in lpb.system_settings:
+        print("    {}: {}".format(setting["name"], setting["value"]))
+
+
+EDITABLE_STRINGS = {
+    "project_name": "Project Name",
+    "project_dir": "Project Directory",
+    "init_lsb": "Initial LSB",
+    "exit_lsb": "Exit LSB",
+}
+
+
+@lmlpb.command()
+@click.argument("lpb_file", required=True, type=click.Path(exists=True, dir_okay=False))
+def edit(lpb_file):
+    """Edit the specified LPB file.
+
+    Only specific settings can be edited.
+
+    The original LSB file will be backed up to <lpb_file>.bak
+
+    Note: Setting empty fields to improper data types may cause
+    undefined behavior in the LiveMaker engine. When editing a field,
+    the data type of the new value is assumed to be the same as the
+    original data type.
+
+    """
+    with open(lpb_file, "rb") as f:
+        try:
+            lpb = LMProject.from_file(f)
+        except LiveMakerException as e:
+            sys.exit("Could not open LPB file: {}".format(e))
+
+    print("Editing LM project {}".format(lpb_file))
+    for key in lpb.keys():
+        orig = getattr(lpb, key)
+        if key in EDITABLE_STRINGS:
+            name = EDITABLE_STRINGS[key]
+            value = click.prompt(name, orig)
+            if value != orig:
+                setattr(lpb, key, value)
+        elif key != "system_settings":
+            print("{} [{}]: <skipping uneditable field>".format(key, orig))
+    print("System settings:")
+    for setting in lpb.system_settings:
+        name = setting["name"]
+        orig = setting["value"]
+        param_type = setting["type"]
+        param = Param(value=orig, type=ParamType[param_type])
+        _edit_parser_op(param, prompt="  {}".format(name))
+        if param.value != orig:
+            setting["value"] = param.value
+        print(lpb.system_settings)
+
+    print("Backing up original LPB.")
+    shutil.copyfile(str(lpb_file), "{}.bak".format(str(lpb_file)))
+    try:
+        new_lpb_data = lpb.to_lpb()
+        with open(lpb_file, "wb") as f:
+            f.write(new_lpb_data)
+        print("Wrote new LPB.")
+    except LiveMakerException as e:
+        sys.exit("Could not generate new LPB file: {}".format(e))

--- a/livemaker/cli/lmlpb.py
+++ b/livemaker/cli/lmlpb.py
@@ -42,9 +42,7 @@ def lmlpb():
 @lmlpb.command()
 @click.argument("input_file", metavar="file", required=True, type=click.Path(exists=True, dir_okay=False))
 def probe(input_file):
-    """Output information about the specified LPB file in human-readable form.
-
-    """
+    """Output information about the specified LPB file in human-readable form."""
     print(input_file)
     with open(input_file, "rb") as f:
         try:
@@ -65,8 +63,8 @@ def probe(input_file):
 EDITABLE_STRINGS = {
     "project_name": "Project Name",
     "project_dir": "Project Directory",
-    "init_lsb": "Initial LSB",
-    "exit_lsb": "Exit LSB",
+    "init_lsb": "Initial LSB (run at startup)",
+    "exit_lsb": "Exit LSB (run at exit)",
 }
 
 
@@ -77,7 +75,7 @@ def edit(lpb_file):
 
     Only specific settings can be edited.
 
-    The original LSB file will be backed up to <lpb_file>.bak
+    The original LPB file will be backed up to <lpb_file>.bak
 
     Note: Setting empty fields to improper data types may cause
     undefined behavior in the LiveMaker engine. When editing a field,

--- a/livemaker/exceptions.py
+++ b/livemaker/exceptions.py
@@ -22,13 +22,9 @@
 class LiveMakerException(Exception):
     """Base pylivemaker exception."""
 
-    pass
-
 
 class BadLiveMakerArchive(LiveMakerException):
     """Error raised for bad/invalid archive files."""
-
-    pass
 
 
 class UnsupportedLiveMakerVersion(LiveMakerException):
@@ -42,10 +38,10 @@ class UnsupportedLiveMakerCompression(LiveMakerException):
 class BadLsbError(LiveMakerException):
     """Error raised for bad/invalid LSB script files."""
 
-    pass
+
+class BadLpbError(LiveMakerException):
+    """Error raised for bad/invalid LPB project settings files."""
 
 
 class BadLnsError(LiveMakerException):
     """Error raised for bad/invalid LNS novel scripts."""
-
-    pass

--- a/livemaker/lpb.py
+++ b/livemaker/lpb.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8
+#
+# Copyright (C) 2020 Peter Rowlands <peter@pmrowla.com>
+# Copyright (C) 2014 tinfoil <https://bitbucket.org/tinfoil/>
+#
+# This file is a part of pylivemaker.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+"""LiveMaker project settings file (LPB) module."""
+
+from io import IOBase
+
+import construct
+import numpy
+
+from .exceptions import BadLpbError
+from .lsb.core import ParamType
+from .lsb.lmscript import DEFAULT_LSB_VERSION, LsbVersionValidator, lsb_to_lm_ver
+
+
+class LMProject:
+    """Class for handling project settings files.
+
+    RE'd from TProject, TProjectSettings classes in LiveMaker code.
+
+    """
+
+    def __init__(
+        self,
+        version=DEFAULT_LSB_VERSION,
+        project_name="",
+        unk1=0,
+        unk2=0,
+        init_lsb="",
+        exit_lsb="",
+        project_dir="",
+        unk3=0,
+        bool1=0,
+        bool2=0,
+        audio_formats=".wav.wma.ogg.mid.mp3",
+        bool3=0,
+        bool4=0,
+        bool5=1,
+        insert_disk_prompt="",
+        exit_prompt="",
+        system_settings=[],
+        **kwargs
+    ):
+        self.version = version
+        self.project_name = project_name
+        self.unk1 = unk1
+        self.unk2 = unk2
+        self.init_lsb = init_lsb
+        self.exit_lsb = exit_lsb
+        self.project_dir = project_dir
+        self.unk3 = unk3
+        self.bool1 = bool1
+        self.bool2 = bool2
+        self.audio_formats = audio_formats
+        self.bool3 = bool3
+        self.bool4 = bool4
+        self.bool5 = bool5
+        self.insert_disk_prompt = insert_disk_prompt
+        self.exit_prompt = exit_prompt
+        if isinstance(system_settings, construct.ListContainer):
+            settings = []
+            for setting in system_settings:
+                settings.append({"name": setting.name, "type": str(setting.type), "value": setting.value})
+            self.system_settings = settings
+        else:
+            self.system_settings = system_settings
+
+    def __iter__(self):
+        return iter(self.items())
+
+    def __getitem__(self, key):
+        if key in self.keys():
+            return getattr(self, key)
+        raise KeyError
+
+    def keys(self):
+        return [
+            "version",
+            "project_name",
+            "unk1",
+            "unk2",
+            "init_lsb",
+            "exit_lsb",
+            "project_dir",
+            "unk3",
+            "bool1",
+            "bool2",
+            "audio_formats",
+            "bool3",
+            "bool4",
+            "bool5",
+            "insert_disk_prompt",
+            "exit_prompt",
+            "system_settings",
+        ]
+
+    def items(self):
+        return [(k, self[k]) for k in self.keys()]
+
+    @property
+    def lm_version(self):
+        return lsb_to_lm_ver(self.version)
+
+    @classmethod
+    def _struct(cls):
+        return construct.Struct(
+            "version" / LsbVersionValidator(construct.Int32ul),
+            "project_name" / construct.PascalString(construct.Int32ul, "cp932"),
+            "unk1" / construct.Int64ul,
+            "unk2" / construct.Int64ul,
+            "init_lsb" / construct.PascalString(construct.Int32ul, "cp932"),
+            "exit_lsb"
+            / construct.If(construct.this.version > 0x6D, construct.PascalString(construct.Int32ul, "cp932"),),
+            "project_dir" / construct.PascalString(construct.Int32ul, "cp932"),
+            "unk3" / construct.Int32ul,
+            "bool1" / construct.Byte,
+            "bool2" / construct.If(construct.this.version >= 0x6A, construct.Byte,),
+            "audio_formats"
+            / construct.If(construct.this.version >= 0x6D, construct.PascalString(construct.Int32ul, "cp932"),),
+            "bool3" / construct.If(construct.this.version >= 0x71, construct.Byte,),
+            "bool4" / construct.If(construct.this.version >= 0x72, construct.Byte,),
+            "bool5" / construct.If(construct.this.version >= 0x74, construct.Byte,),
+            "insert_disk_prompt" / construct.PascalString(construct.Int32ul, "cp932"),
+            "exit_prompt" / construct.PascalString(construct.Int32ul, "cp932"),
+            "system_settings"
+            / construct.PrefixedArray(
+                construct.Int32ul,
+                construct.Struct(
+                    "type" / construct.Enum(construct.Byte, ParamType),
+                    "name" / construct.PascalString(construct.Int32ul, "cp932"),
+                    "value"
+                    / construct.Switch(
+                        construct.this.type,
+                        {
+                            "Int": construct.Int32sl,
+                            "Float": construct.ExprAdapter(
+                                construct.Bytes(10),
+                                lambda obj, ctx: numpy.frombuffer(obj.rjust(16, b"\x00"), dtype=numpy.longdouble),
+                                lambda obj, ctx: numpy.longdouble(obj).tobytes()[-10:],
+                            ),
+                            "Flag": construct.Byte,
+                            "Str": construct.PascalString(construct.Int32ul, "cp932"),
+                        },
+                    ),
+                ),
+            ),
+        )
+
+    @classmethod
+    def from_struct(cls, struct, **kwargs):
+        """Create an LMProject from the specified struct."""
+        if isinstance(struct, construct.Container):
+            d = {k: v for k, v in struct.items()}
+            d.update(kwargs)
+            return cls(**d)
+        raise NotImplementedError
+
+    @classmethod
+    def from_file(cls, infile):
+        """Parse the specified file into an LMProject.
+
+        Args:
+            infile: Input .lpb file. Can be string, path-like or file-like object.
+
+        """
+        if not isinstance(infile, IOBase):
+            infile = open(infile, "rb")
+        try:
+            return cls.from_struct(cls._struct().parse_stream(infile))
+        except construct.ConstructError as e:
+            raise BadLpbError(e)
+
+    def to_lpb(self):
+        """Compile settings into binary .lpb format."""
+        try:
+            return self._struct().build(self)
+        except construct.ConstructError as e:
+            raise BadLpbError(e)

--- a/livemaker/lsb/core.py
+++ b/livemaker/lsb/core.py
@@ -485,7 +485,7 @@ class Param(BaseSerializable):
             / construct.Switch(
                 construct.this.type,
                 {
-                    "Int": construct.Int32ul,
+                    "Int": construct.Int32sl,
                     "Float": construct.ExprAdapter(
                         construct.Bytes(10),
                         lambda obj, ctx: numpy.frombuffer(obj.rjust(16, b"\x00"), dtype=numpy.longdouble),

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         "console_scripts": [
             "lmar=livemaker.cli:lmar",
             "lmgraph=livemaker.cli:lmgraph",
+            "lmlpb=livemaker.cli:lmlpb",
             "lmlsb=livemaker.cli:lmlsb",
             "lmpatch=livemaker.cli:lmpatch",
             "galconvert=livemaker.cli:galconvert",


### PR DESCRIPTION
Related to #11 

`lmlpb` works basically the same way as `lmlsb`, except for LPB project setting files.

* `lmlpb probe` can be used to dump settings from LPB files (live.lpb)
* `lmlpb edit` can be used to edit settings in LPB files