### PR TITLE
lmscript: gracefully handle failed translates

### DIFF
--- a/livemaker/cli/lmlsb.py
+++ b/livemaker/cli/lmlsb.py
@@ -1018,9 +1018,10 @@ def insertmenu(lsb_file, csv_file, encoding, no_backup, verbose):
         for row in csv_reader:
             csv_data.append(row)
 
-    translated, untranslated = _patch_csv_menus(lsb, lsb_file, csv_data, verbose)
+    translated, failed, untranslated = _patch_csv_menus(lsb, lsb_file, csv_data, verbose)
 
     print(f"  Translated {translated} choices")
+    print(f"  Failed to translate {failed} choices")
     print(f"  Ignored {untranslated} untranslated choices")
     if not translated:
         return
@@ -1064,9 +1065,9 @@ def _patch_csv_menus(lsb, lsb_file, csv_data, verbose=False):
                     print(f"{id_} Ignoring untranslated text '{orig_text}'")
                 untranslated += 1
 
-    lsb.replace_text(text_objects)
+    translated, failed = lsb.replace_text(text_objects)
 
-    return len(text_objects), untranslated
+    return translated, failed, untranslated
 
 
 @lmlsb.command()
@@ -1157,9 +1158,9 @@ def _patch_csv_text(lsb, lsb_file, csv_data, verbose=False):
                     print(f"{id_} Ignoring untranslated text '{orig_text}'")
                 untranslated += 1
 
-    lsb.replace_text(text_objects)
+    translated, failed = lsb.replace_text(text_objects)
 
-    return len(text_objects), untranslated
+    return translated, failed, untranslated
 
 
 @lmlsb.command()
@@ -1198,8 +1199,9 @@ def insertcsv(lsb_file, csv_file, encoding, no_backup, verbose):
         for row in csv_reader:
             csv_data.append(row)
 
-    translated, untranslated = _patch_csv_text(lsb, lsb_file, csv_data, verbose)
+    translated, failed, untranslated = _patch_csv_text(lsb, lsb_file, csv_data, verbose)
     print(f"  Translated {translated} lines")
+    print(f"  Failed to translate {failed} lines")
     print(f"  Ignored {untranslated} untranslated lines")
     if not translated:
         return

--- a/livemaker/exceptions.py
+++ b/livemaker/exceptions.py
@@ -47,5 +47,12 @@ class BadLnsError(LiveMakerException):
     """Error raised for bad/invalid LNS novel scripts."""
 
 
+class InvalidCharError(BadLnsError):
+    def __init__(self, ch, encoding="cp932"):
+        self.ch = ch
+        self.encoding = encoding
+        super().__init__(f"'{ch}' is not a valid {encoding.upper()} character.")
+
+
 class BadTextIdentifierError(LiveMakerException):
     """Error raised for bad/invalid translatable text IDs."""

--- a/livemaker/lsb/lmscript.py
+++ b/livemaker/lsb/lmscript.py
@@ -41,7 +41,7 @@ from .core import BaseSerializable
 from .command import CommandType, PropertyType, _command_classes, _command_structs
 from .menu import BaseSelectionMenu, make_menu, MENU_IDENTIFIERS
 from .translate import TextBlockIdentifier
-from ..exceptions import BadLsbError, BadTextIdentifierError, InvalidCharError, LiveMakerException
+from ..exceptions import BadLsbError, BadTextIdentifierError, LiveMakerException
 
 
 # Known LSB format versions
@@ -587,8 +587,8 @@ class LMScript(BaseSerializable):
                     block.text = text
                     logger.info(f"Translated block {id_}: '{block.orig_text}' -> '{block.text}'")
                     translated += 1
-                except InvalidCharError as e:
-                    logger.warning(f"Could not translate block {id_}: {e}")
+                except LiveMakerException as e:
+                    logger.warning(f"Failed to translate text block <{id_}> {e}")
                     failed += 1
             scenario.replace_text_blocks(tmp_blocks)
         return translated, failed
@@ -677,7 +677,7 @@ class LMScript(BaseSerializable):
                     logger.info(f"Translated '{choice.orig_text}' -> '{choice.text}'")
                     translated += 1
                 except LiveMakerException as e:
-                    logger.warning(f"Failed to translate menu choice {id_}: {e}")
+                    logger.warning(f"Failed to translate menu choice <{id_}> {e}")
                     failed += 1
             menu.save_choices()
         return translated, failed

--- a/livemaker/lsb/lmscript.py
+++ b/livemaker/lsb/lmscript.py
@@ -41,7 +41,7 @@ from .core import BaseSerializable
 from .command import CommandType, PropertyType, _command_classes, _command_structs
 from .menu import BaseSelectionMenu, make_menu, MENU_IDENTIFIERS
 from .translate import TextBlockIdentifier
-from ..exceptions import BadLsbError, BadTextIdentifierError, LiveMakerException
+from ..exceptions import BadLsbError, BadTextIdentifierError, InvalidCharError, LiveMakerException
 
 
 # Known LSB format versions
@@ -575,8 +575,11 @@ class LMScript(BaseSerializable):
             tmp_blocks = scenario.get_text_blocks()
             for id_, text in replacement_blocks[line_no]:
                 block = tmp_blocks[id_.block_index]
-                block.text = text
-                logger.info(f"Translated '{block.orig_text}' -> '{block.text}'")
+                try:
+                    block.text = text
+                    logger.info(f"Translated block {id_}: '{block.orig_text}' -> '{block.text}'")
+                except InvalidCharError as e:
+                    logger.warn(f"Could not translate block {id_}: {e}")
             scenario.replace_text_blocks(tmp_blocks)
 
     def get_menus(self, run_order=True):

--- a/livemaker/lsb/novel.py
+++ b/livemaker/lsb/novel.py
@@ -31,7 +31,7 @@ from loguru import logger
 from lxml import etree
 
 from .core import BaseSerializable, LiveParser
-from ..exceptions import BadLnsError
+from ..exceptions import BadLnsError, InvalidCharError
 from .translate import BaseTranslatable
 
 
@@ -253,7 +253,7 @@ class TWdChar(BaseTWdReal):
         try:
             ch.encode("cp932")
         except UnicodeEncodeError:
-            raise BadLnsError("'{}' is not a valid CP932 character".format(ch))
+            raise InvalidCharError(ch)
         self._keys.update(("ch", "decorator"))
         self.ch = ch
         self.decorator = decorator

--- a/livemaker/lsb/translate.py
+++ b/livemaker/lsb/translate.py
@@ -23,7 +23,7 @@ from hashlib import blake2b
 
 from funcy import cached_property
 
-from ..exceptions import BadTextIdentifierError
+from ..exceptions import BadTextIdentifierError, InvalidCharError
 
 
 class BaseTranslatable(ABC):
@@ -43,6 +43,11 @@ class BaseTranslatable(ABC):
 
     @text.setter
     def text(self, text):
+        for ch in text:
+            try:
+                ch.encode("cp932")
+            except UnicodeEncodeError:
+                raise InvalidCharError(ch)
         self._text = text.splitlines()
 
     @cached_property


### PR DESCRIPTION
If text replace via the new apis fails, we log the error as a warning (including the object ID so you can ctrl-f your csv for the bad row), and continue trying to patch remaining text objects. CLI tools output a final count of success/failed/ignored

Partial fix for #53 