### PR TITLE
support label name lookup

### DIFF
--- a/livemaker/cli/lmlsb.py
+++ b/livemaker/cli/lmlsb.py
@@ -1025,9 +1025,11 @@ def insertmenu(lsb_file, csv_file, encoding, no_backup, verbose):
     lsb_file = Path(lsb_file)
     print("Patching {} ...".format(lsb_file))
 
+    pylm = PylmProject(lsb_file)
+    call_name = pylm.call_name(lsb_file)
     try:
         with open(lsb_file, "rb") as f:
-            lsb = LMScript.from_file(f)
+            lsb = LMScript.from_file(f, pylm=pylm, call_name=call_name)
     except BadLsbError as e:
         sys.exit("Failed to parse file: {}".format(e))
 
@@ -1121,9 +1123,11 @@ def extractcsv(lsb_file, csv_file, encoding, overwrite, append):
     lsb_file = Path(lsb_file)
     print("Extracting {} ...".format(lsb_file))
 
+    pylm = PylmProject(lsb_file)
+    call_name = pylm.call_name(lsb_file)
     try:
         with open(lsb_file, "rb") as f:
-            lsb = LMScript.from_file(f)
+            lsb = LMScript.from_file(f, call_name=call_name, pylm=pylm)
     except BadLsbError as e:
         sys.exit("Failed to parse file: {}".format(e))
 
@@ -1206,9 +1210,11 @@ def insertcsv(lsb_file, csv_file, encoding, no_backup, verbose):
     lsb_file = Path(lsb_file)
     print("Patching {} ...".format(lsb_file))
 
+    pylm = PylmProject(lsb_file)
+    call_name = pylm.call_name(lsb_file)
     try:
         with open(lsb_file, "rb") as f:
-            lsb = LMScript.from_file(f)
+            lsb = LMScript.from_file(f, call_name=call_name, pylm=pylm)
     except BadLsbError as e:
         sys.exit("Failed to parse file: {}".format(e))
 

--- a/livemaker/lsb/lmscript.py
+++ b/livemaker/lsb/lmscript.py
@@ -26,7 +26,6 @@ Attributes:
 """
 
 import math
-import os
 from collections import defaultdict, deque
 from copy import copy
 from io import IOBase
@@ -367,7 +366,7 @@ class LMScript(BaseSerializable):
         return lm
 
     @classmethod
-    def from_file(cls, infile):
+    def from_file(cls, infile, **kwargs):
         """Parse the specified file into an LMScript.
 
         Args:
@@ -381,13 +380,12 @@ class LMScript(BaseSerializable):
             infile = open(infile, "rb")
         data = infile.read(9)
         infile.seek(0)
-        name = os.path.basename(infile.name)
         if data.startswith(b"LiveMaker"):
-            return cls.from_lsc(infile.read().decode("cp932"), call_name=name)
+            return cls.from_lsc(infile.read().decode("cp932"), **kwargs)
         elif data.startswith(b"<?xml"):
-            return cls.from_xml(etree.parse(infile), call_name=name)
+            return cls.from_xml(etree.parse(infile), **kwargs)
         try:
-            return cls.from_struct(cls._struct().parse_stream(infile), call_name=name)
+            return cls.from_struct(cls._struct().parse_stream(infile), **kwargs)
         except construct.ConstructError as e:
             raise BadLsbError(e)
 

--- a/livemaker/lsb/lmscript.py
+++ b/livemaker/lsb/lmscript.py
@@ -143,6 +143,7 @@ class LMScript(BaseSerializable):
             logger.warning("len(command_params) exceeds max command type value")
         self.command_params = command_params
         self.commands = commands
+        self.pylm = kwargs.get("pylm")
 
     def __len__(self):
         return len(self.commands)
@@ -620,7 +621,7 @@ class LMScript(BaseSerializable):
                 return menus
             if BaseSelectionMenu.is_menu_start(cmd):
                 try:
-                    menu = make_menu(self, i)
+                    menu = make_menu(self, i, pylm=self.pylm)
                     menus.append((cmd.LineNo, menu))
                 except LiveMakerException:
                     pass

--- a/livemaker/lsb/lmscript.py
+++ b/livemaker/lsb/lmscript.py
@@ -29,6 +29,7 @@ import math
 from collections import defaultdict, deque
 from copy import copy
 from io import IOBase
+from pathlib import Path
 
 import construct
 
@@ -381,6 +382,8 @@ class LMScript(BaseSerializable):
             infile = open(infile, "rb")
         data = infile.read(9)
         infile.seek(0)
+        if "call_name" not in kwargs:
+            kwargs["call_name"] = Path(infile.name).name
         if data.startswith(b"LiveMaker"):
             return cls.from_lsc(infile.read().decode("cp932"), **kwargs)
         elif data.startswith(b"<?xml"):

--- a/livemaker/lsb/menu.py
+++ b/livemaker/lsb/menu.py
@@ -396,7 +396,7 @@ class LPMSelectionMenu(BaseSelectionMenu):
             raise NotSelectionMenuError
         for text in jumps:
             target, index = jumps[text]
-            jumps[text] = cls._resolve_int_jump(target, index, lsb)
+            jumps[text] = cls._resolve_int_jump(target, index, lsb), index
 
         menu = cls(lsb, lpm_file, label=label)
         for src_file, name in choices:

--- a/livemaker/lsb/menu.py
+++ b/livemaker/lsb/menu.py
@@ -19,7 +19,7 @@
 """LiveMaker LiveNovel selection menu classes."""
 
 import re
-from pathlib import PurePath, PureWindowsPath
+from pathlib import Path, PureWindowsPath
 
 from .command import CommandType
 from .core import OpeDataType, ParamType
@@ -40,7 +40,7 @@ class BaseSelectionMenu:
     END_SELECTION_CALCS = ["選択実行中 = 0"]
     EXECUTE_LSB = None
 
-    def __init__(self, lsb, choices=[], label=None):
+    def __init__(self, lsb, choices=[], label=None, **kwargs):
         self.lsb = lsb
         self.label = label
         self._choices = []
@@ -76,7 +76,7 @@ class BaseSelectionMenu:
             return True
 
     @classmethod
-    def from_lsb_command(cls, lsb, start):
+    def from_lsb_command(cls, lsb, start, **kwargs):
         """Return a selection menu constructed from the LSB commands
         starting at index.
 
@@ -267,7 +267,7 @@ class TextSelectionMenu(BaseSelectionMenu):
             self._patch_int_jump_cmd(cmd, choice.text)
 
     @classmethod
-    def from_lsb_command(cls, lsb, start):
+    def from_lsb_command(cls, lsb, start, **kwargs):
         try:
             cmd = lsb.commands[start]
             if not cls.is_menu_start(cmd):
@@ -359,19 +359,28 @@ class LPMSelectionMenu(BaseSelectionMenu):
         }
 
     @classmethod
-    def _choices_from_lpm(cls, filename):
+    def _choices_from_lpm(cls, filename, pylm=None):
         try:
-            path = PurePath(PureWindowsPath(filename.strip('"')))
+            path = PureWindowsPath(filename.strip('"'))
+            if pylm:
+                path = pylm.root / path
+            else:
+                # convert windows purepath to system path
+                path = Path(path)
             lpm = LMLivePrevMenu.from_file(path)
             choices = []
             for button in lpm["buttons"]:
-                choices.append((button.get("src"), button.get("name")))
+                src_file = button.get("src")
+                if src_file and pylm:
+                    src_file = path / PureWindowsPath(src_file)
+                    src_file = src_file.resolve().relative_to(pylm.root)
+                choices.append((src_file, button.get("name")))
             return choices
         except LiveMakerException:
             return []
 
     @classmethod
-    def from_lsb_command(cls, lsb, start):
+    def from_lsb_command(cls, lsb, start, pylm=None):
         try:
             cmd = lsb.commands[start]
             if not cls.is_menu_start(cmd):
@@ -387,7 +396,7 @@ class LPMSelectionMenu(BaseSelectionMenu):
             raise NotSelectionMenuError
         params = cls._parse_params(params)
         lpm_file = params["menu_file"].strip('"')
-        choices = cls._choices_from_lpm(lpm_file)
+        choices = cls._choices_from_lpm(lpm_file, pylm=pylm)
         if not choices:
             raise NotSelectionMenuError
 
@@ -415,10 +424,10 @@ MENU_IDENTIFIERS = {
 }
 
 
-def make_menu(lsb, index):
+def make_menu(lsb, index, **kwargs):
     for cls in MENU_IDENTIFIERS:
         try:
-            return cls.from_lsb_command(lsb, index)
+            return cls.from_lsb_command(lsb, index, **kwargs)
         except NotSelectionMenuError:
             pass
     raise NotSelectionMenuError

--- a/livemaker/project.py
+++ b/livemaker/project.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 Peter Rowlands <peter@pmrowla.com>
+# Copyright (C) 2014 tinfoil <https://bitbucket.org/tinfoil/>
+#
+# This file is a part of pylivemaker.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+"""pylivemaker project management module."""
+
+import os
+from collections import defaultdict
+from pathlib import Path, PurePath, PureWindowsPath
+
+from .exceptions import LiveMakerException
+from .lsb.command import CommandType
+from .lsb.lmscript import LMScript
+
+
+class PylmProject:
+    def __init__(self, path):
+        self.root = self.find_root(path)
+        if not self.root:
+            raise LiveMakerException(f"{path} is not inside a LM project")
+        self._label_cache = defaultdict(dict)
+
+    @staticmethod
+    def find_root(path):
+        """Return root LM project dir for the specified path."""
+        path = Path(path).resolve()
+        if not path.exists():
+            return None
+        if path.is_file():
+            path = path.parent
+        search_names = {"live.lsb", "ゲームメイン.lsb", "ノベルシステム"}
+        for search_dir in [path] + list(reversed(path.parents)):
+            if set(os.listdir(search_dir)) & search_names:
+                return search_dir
+        return None
+
+    def call_name(self, path):
+        path = Path(path).resolve()
+        if path.suffix not in (".lsb", ".lsc"):
+            raise LiveMakerException(f"{path} is not an LSB")
+        try:
+            relpath = PureWindowsPath(path.relative_to(self.root))
+            return str(relpath.parent / f"{relpath.stem}.lsb")
+        except ValueError:
+            raise LiveMakerException(f"{path} is outside this project")
+
+    def update_labels(self, lsb):
+        """Update labels from the specified lsb."""
+        if not lsb.call_name:
+            raise LiveMakerException("Cannot update labels for lsb without call_name")
+        names = {}
+        lines = {}
+        for cmd in lsb.commands:
+            if cmd.type == CommandType.Label:
+                name = cmd["Name"]
+                names[name] = cmd.LineNo
+                lines[cmd.LineNo] = name
+        cache = self._label_cache[lsb.call_name]
+        if "names" in cache:
+            cache["names"].update(names)
+        else:
+            cache["names"] = names
+        if "lines" in cache:
+            cache["lines"].update(lines)
+        else:
+            cache["lines"] = lines
+
+    def resolve_label(self, ref):
+        """Return tuple(line_no, name) for the specified label reference."""
+        # Page is a rel path with windows slash, we need to convert it to
+        # system path on posix
+        if isinstance(ref.Label, int) and ref.Label == 0:
+            # start of script is not labeled
+            return None, None
+
+        path = PurePath(PureWindowsPath(ref.Page))
+        call_name = self.call_name(path)
+        if call_name not in self._label_cache:
+            path = self.root / call_name
+            try:
+                lsb = LMScript.from_file(path, call_name=call_name)
+                self.update_labels(lsb)
+            except LiveMakerException:
+                raise LiveMakerException(f"Could not update labels from {call_name}")
+        cache = self._label_cache[call_name]
+        if isinstance(ref.Label, int):
+            name = cache["lines"].get(ref.Label)
+            if name:
+                return (ref.Label, name)
+        else:
+            line_no = cache["names"].get(ref.Label)
+            if line_no is not None:
+                return (line_no, ref.Label)
+        return None, None

--- a/livemaker/project.py
+++ b/livemaker/project.py
@@ -42,7 +42,7 @@ class PylmProject:
             return None
         if path.is_file():
             path = path.parent
-        search_names = {"live.lsb", "ゲームメイン.lsb", "ノベルシステム"}
+        search_names = {"live.lpb", "ゲームメイン.lsb", "ノベルシステム"}
         for search_dir in [path] + list(reversed(path.parents)):
             if set(os.listdir(search_dir)) & search_names:
                 return search_dir

--- a/livemaker/project.py
+++ b/livemaker/project.py
@@ -20,7 +20,7 @@
 
 import os
 from collections import defaultdict
-from pathlib import Path, PurePath, PureWindowsPath
+from pathlib import Path, PureWindowsPath
 
 from .exceptions import LiveMakerException
 from .lsb.command import CommandType
@@ -87,7 +87,7 @@ class PylmProject:
             # start of script is not labeled
             return None, None
 
-        path = PurePath(PureWindowsPath(ref.Page))
+        path = Path(PureWindowsPath(ref.Page))
         call_name = self.call_name(path)
         if call_name not in self._label_cache:
             path = self.root / call_name


### PR DESCRIPTION
Related to #38

* LPM menu now resolves relative paths for button images
* `lmlsb dump` output now includes resolved names for branch (jump/call/etc)
  targets
* `lmlsb extractmenu` now includes resolved names for choice targets