### PR TITLE
[cli] add lmbmp

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -503,8 +503,8 @@ PIL/Pillow.
     If a GAL image contains multiple frames, only the first frame will be used when converting to a format which
     does not support multiple frames.
 
-    Conversion to GAL format is not currently supported. If you need to generate GAL images, it is recommended to
-    use LiveMaker's ``BmpToGale`` program.
+    Direct conversion to GAL format is not currently supported. If you need to generate GAL images,
+    it is recommended to use LiveMaker's ``BmpToGale`` program in conjunction with ``lmbmp``.
 
 ::
 
@@ -519,5 +519,25 @@ PIL/Pillow.
       Output format will be determined based on file extension.
 
     Options:
+      -f, --force  Overwrite output file if it exists.
+      --help       Show this message and exit.
+
+lmbmp
+-----
+
+``lmbmp`` can be used to convert an image to a set of bitmap files which can then be used with LiveMaker's
+``BmpToGale`` tool. ::
+
+    $ lmbmp --help
+    Usage: lmbmp [OPTIONS] INPUT_FILE
+
+      Convert image to BMP(s) which can be used with bmp2gale.
+
+      If the input file contains an alpha layer, a mask bitmap will be
+      generated. Output files will be named <input_name>.bmp and
+      <input_name>-m.bmp.
+
+    Options:
+      --version    Show the version and exit.
       -f, --force  Overwrite output file if it exists.
       --help       Show this message and exit.

--- a/livemaker/cli/__init__.py
+++ b/livemaker/cli/__init__.py
@@ -24,14 +24,14 @@ import sys
 
 from loguru import logger
 
-from .cli import galconvert
+from .cli import galconvert, lmbmp
 from .lmar import lmar
 from .lmgraph import lmgraph
 from .lmlpb import lmlpb
 from .lmlsb import lmlsb
 from .lmpatch import lmpatch
 
-__all__ = ["galconvert", "lmar", "lmgraph", "lmlpb", "lmlsb", "lmpatch"]
+__all__ = ["galconvert", "lmar", "lmbmp", "lmgraph", "lmlpb", "lmlsb", "lmpatch"]
 
 
 logger.remove()

--- a/livemaker/cli/cli.py
+++ b/livemaker/cli/cli.py
@@ -61,11 +61,45 @@ def galconvert(force, input_file, output_file):
     """
     try:
         im = Image.open(input_file)
-    except IOError as e:
-        raise e
-        # sys.exit('Error opening {}: {}'.format(input_file, e))
+    except OSError as e:
+        sys.exit(f"Error opening {input_file}: {e}")
     if Path(output_file).exists() and not force:
-        sys.exit("{} already exists".format(output_file))
-    print("Converting {} to {}".format(input_file, output_file))
+        sys.exit(f"{output_file} already exists")
+    print(f"Converting {input_file} to {output_file}")
     im.load()
+    im.save(output_file)
+
+
+@click.command()
+@click.version_option(version=__version__, message=_version)
+@click.option("-f", "--force", is_flag=True, default=False, help="Overwrite output file if it exists.")
+@click.argument("input_file", required=True, type=click.Path(exists=True, dir_okay=False))
+def lmbmp(force, input_file):
+    """Convert image to BMP(s) which can be used with bmp2gale.
+
+    If the input file contains an alpha layer, a mask bitmap will be generated.
+    Output files will be named <input_name>.bmp and <input_name>-m.bmp.
+    """
+    input_file = Path(input_file)
+    try:
+        im = Image.open(input_file)
+    except IOError as e:
+        sys.exit(f"Error opening {input_file}: {e}")
+    name = Path(input_file.stem)
+    output_file = input_file.parent / f"{name}.bmp"
+    if Path(output_file).exists() and not force:
+        sys.exit(f"{output_file} already exists")
+
+    try:
+        mask = im.getchannel("A")
+        output_mask = input_file.parent / f"{name}-m.bmp"
+        if Path(output_mask).exists() and not force:
+            sys.exit(f"{output_mask} already exists")
+        print(f"Generating mask {output_mask}")
+        mask.save(output_mask)
+    except ValueError:
+        pass
+
+    print(f"Converting {input_file} to {output_file}")
+    im = im.convert("RGB")
     im.save(output_file)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ requirements = [
     "lxml>=4.3",
     "networkx>=2.4",
     "numpy>=1.16",
-    "Pillow>=6.2.1",
+    "Pillow>=7.1.2",
     "pydot>=1.4.1",
 ]
 
@@ -51,6 +51,7 @@ setup(
             "lmlsb=livemaker.cli:lmlsb",
             "lmpatch=livemaker.cli:lmpatch",
             "galconvert=livemaker.cli:galconvert",
+            "lmbmp=livemaker.cli:lmbmp",
         ],
     },
     install_requires=requirements,


### PR DESCRIPTION
adds lmbmp helper utility

* can be used to generate bitmaps (including the `-m.bmp` mask) for conversion with BmpToGale

Should be good enough as a placeholder until we have proper GAL encoder support

related to #65 