### PR TITLE
Fix an issue where on macOS calling click.get_terminal_size() is missing

### DIFF
--- a/livemaker/cli/lmpatch.py
+++ b/livemaker/cli/lmpatch.py
@@ -115,7 +115,7 @@ def lmpatch(archive_file, patched_lsb, split, no_backup, force, recursive):
         ) as new_lm:
 
             def bar_show(item):
-                width, _ = click.get_terminal_size()
+                width, _ = shutil.get_terminal_size()
                 width //= 4
                 name = item.name if item is not None else ""
                 if len(name) > width:


### PR DESCRIPTION
I cannot confirm if this affect other platforms, but on macOS, the click library does not have .get_terminal_size() and makes the patch utility unusable. This patch uses the built-in shutil. get_terminal_size instead and looks like it provides the same functionality.