### PR TITLE
fix reading TXSPD

### DIFF
--- a/livemaker/lsb/novel.py
+++ b/livemaker/lsb/novel.py
@@ -1577,7 +1577,7 @@ class LNSCompiler(_markupbase.ParserBase):
             if ruby:
                 self.ruby_text[self.decorator] = ruby
         elif tag == LNSTag.txspd:
-            self.text_speed = int(attrs.get("TIME"), 50)
+            self.text_speed = int(attrs.get("TIME", 50))
         elif tag == LNSTag.txspn:
             self.text_speed = 50
         elif tag == LNSTag.txspf:


### PR DESCRIPTION
It was trying to get the value as "base-50" positional numeral system, instead of getting attr with default value 50.
> ValueError: int() base must be >= 2 and <= 36, or 0